### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "engines": {
     "node": ">=24"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-convert-to-hls",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "repository": "https://github.com/bossoq/auto-convert-to-hls.git",
   "author": "Kittipos Wajakajornrit <kwajakajornrit@gmail.com>",
   "license": "MIT",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary

- Bump root, backend, and web `package.json` versions from `1.2.0`/`0.1.0`/`0.0.1` → `2.0.0`

## What's in 2.0

- SvelteKit v2 migration (Vite 5, Svelte 4, Node 24 compatibility)
- Vitest test suite (37 tests) + CI test workflow
- Bug fixes: CORS wildcard, stuck transcoder queue, `forEach(async)` race conditions, missing `k` suffix on FFmpeg bitrate
- Node 24 upgrade across Docker, CI, and tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)