### PR TITLE
Fix release.yml workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   # that have the `release` label applied before merge.
   # The previous `/release` marker in the PR body is no longer used.
   release:
-    if: github.event_name == 'pull_request' && github.event.label.name == 'release'
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/bossoq/line-bot-ai
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest


### PR DESCRIPTION
## Summary

- Fix `release.yml` job condition: `github.event.label.name` only fires on `labeled` events, not `closed`. Changed to `github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')` so it correctly triggers when a labeled PR is merged.
- Fix wrong Docker image name: was hardcoded to `ghcr.io/bossoq/line-bot-ai` (copy-paste from another repo), corrected to `ghcr.io/${{ github.repository }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)