### PR TITLE
Fix Dockerfile web build and release v2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN yarn
 COPY backend/src/ ./backend/src/
 COPY web/src/ ./web/src/
 COPY web/static/ ./web/static/
-COPY web/postcss.config.cjs web/svelte.config.js web/tailwind.config.cjs ./web/
+COPY web/postcss.config.cjs web/svelte.config.js web/vite.config.js web/tailwind.config.cjs ./web/
+
+RUN yarn web build
 
 EXPOSE 3000
 EXPOSE ${PORT}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "engines": {
     "node": ">=24"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-convert-to-hls",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": "https://github.com/bossoq/auto-convert-to-hls.git",
   "author": "Kittipos Wajakajornrit <kwajakajornrit@gmail.com>",
   "license": "MIT",
@@ -9,7 +9,7 @@
     "start": "yarn backend prisma generate && yarn backend-start & yarn web-start",
     "dev": "yarn backend-dev & yarn web-dev",
     "backend-start": "yarn backend start",
-    "web-start": "yarn web build && PORT=3000 node web/build/index.js",
+    "web-start": "PORT=3000 node web/build/index.js",
     "backend-dev": "yarn backend dev",
     "web-dev": "yarn web dev",
     "backend": "yarn workspace backend",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary

- Fix Dockerfile: add missing `vite.config.js` to COPY so SvelteKit plugin loads correctly
- Build web at image build time (`RUN yarn web build`) instead of at container startup
- Update `web-start` script to just `node web/build/index.js` — no redundant rebuild at runtime
- Bump all packages to v2.0.1

## Test plan

- [ ] Docker image builds without "Could not resolve entry module index.html" error
- [ ] Container starts and web UI is accessible on port 3000
- [ ] Backend API accessible on configured PORT

🤖 Generated with [Claude Code](https://claude.com/claude-code)