### PR TITLE
Fix web Docker build and release v2.0.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "engines": {
     "node": ">=24"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-convert-to-hls",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": "https://github.com/bossoq/auto-convert-to-hls.git",
   "author": "Kittipos Wajakajornrit <kwajakajornrit@gmail.com>",
   "license": "MIT",

--- a/web/package.json
+++ b/web/package.json
@@ -1,9 +1,9 @@
 {
   "name": "web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "svelte-kit sync && vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
## Summary

- Run `svelte-kit sync` before `vite build` in the web build script
- `web/tsconfig.json` extends `.svelte-kit/tsconfig.json` which is generated at sync time — without this step the build fails in Docker with "cannot find base config file"
- Bump all packages to v2.0.2

## Test plan

- [ ] Docker image builds without tsconfig base config error
- [ ] Web UI loads correctly after container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)