### PR TITLE
Fix Socket.io xhr poll error and release v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automatically converts MP4 recordings to multi-rendition HLS for video-on-demand
 
 ## Requirements
 
-- Node.js ≥ 10 with Yarn
+- Node.js ≥ 24 with Yarn
 - PostgreSQL database
 - NVIDIA GPU with cuvid support (used for hardware-accelerated transcoding)
 - ffmpeg built with `h264_cuvid` support
@@ -88,7 +88,7 @@ For Google Meet recordings with `autoPublish` enabled, the job also marks the `v
 | `GET /status` | Current job name, frame progress, FPS, speed |
 | `GET /queue` | Pending queue length and job list |
 
-Socket.io emits `status` and `queue` events on every state change, used by the web UI for live updates.
+Socket.io emits `status` and `queue` events on every state change, used by the web UI for live updates. The client connects using WebSocket transport only (no XHR long-polling), which avoids compatibility issues with reverse proxies.
 
 ## Environment Variables
 
@@ -97,7 +97,7 @@ Socket.io emits `status` and `queue` events on every state change, used by the w
 | `SOURCE` | `/source/` | Directory to watch for incoming MP4 files |
 | `DEST` | `/dest/` | Output directory for HLS segments and playlists |
 | `PORT` | `4000` | Backend API / Socket.io port |
-| `CORSHOST` | `https://vodstatus.picturo.us` | Allowed CORS origin for the backend |
+| `CORSHOST` | `https://vodstatus.picturo.us` | Allowed CORS origin(s) for the backend — accepts a single origin or a comma-separated list |
 | `DATABASE_URL` | — | Prisma primary PostgreSQL connection string |
 | `DIRECT_URL` | — | Prisma direct PostgreSQL connection string |
 | `PROJECT_ID` | — | Google Cloud project ID |

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "engines": {
     "node": ">=24"
   },

--- a/backend/src/__tests__/express.test.ts
+++ b/backend/src/__tests__/express.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { parseCorsOrigins } from '../api/express'
+
+describe('parseCorsOrigins', () => {
+  it('returns a string for a single origin', () => {
+    expect(parseCorsOrigins('https://example.com')).toBe('https://example.com')
+  })
+
+  it('returns an array for multiple comma-separated origins', () => {
+    expect(parseCorsOrigins('https://a.com,https://b.com')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ])
+  })
+
+  it('trims spaces around each origin', () => {
+    expect(parseCorsOrigins('https://a.com , https://b.com')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ])
+  })
+
+  it('ignores trailing commas', () => {
+    expect(parseCorsOrigins('https://a.com,')).toBe('https://a.com')
+  })
+
+  it('ignores trailing commas with multiple origins', () => {
+    expect(parseCorsOrigins('https://a.com,https://b.com,')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ])
+  })
+})

--- a/backend/src/api/express.ts
+++ b/backend/src/api/express.ts
@@ -7,26 +7,26 @@ import type { Transcoder } from '../ffmpeg/ffmpeg'
 export class API {
   private app: express.Application
   private port: number
-  private corsHost: string
+  private corsOrigins: string | string[]
   private transcoder: Transcoder
   io: Server
   constructor(transcoder: Transcoder, corsHost: string, port?: number) {
     this.app = express()
     this.port = port || 3000
-    this.corsHost = corsHost
+    this.corsOrigins = corsHost.includes(',') ? corsHost.split(',').map((s) => s.trim()) : corsHost
     this.transcoder = transcoder
     this.init()
   }
 
   private init() {
     const server = http.createServer(this.app)
-    console.log(`Set CORS: ${this.corsHost}`)
+    console.log(`Set CORS: ${this.corsOrigins}`)
     this.io = new Server(server, {
       cors: {
-        origin: this.corsHost,
+        origin: this.corsOrigins,
       },
     })
-    this.app.use(cors({ origin: this.corsHost }))
+    this.app.use(cors({ origin: this.corsOrigins }))
     this.app.use(express.json())
 
     this.app.get('/status', (_req, res) => {

--- a/backend/src/api/express.ts
+++ b/backend/src/api/express.ts
@@ -4,6 +4,11 @@ import cors from 'cors'
 import { Server } from 'socket.io'
 import type { Transcoder } from '../ffmpeg/ffmpeg'
 
+export function parseCorsOrigins(corsHost: string): string | string[] {
+  const origins = corsHost.split(',').map((s) => s.trim()).filter(Boolean)
+  return origins.length === 1 ? origins[0] : origins
+}
+
 export class API {
   private app: express.Application
   private port: number
@@ -13,13 +18,7 @@ export class API {
   constructor(transcoder: Transcoder, corsHost: string, port?: number) {
     this.app = express()
     this.port = port || 3000
-    const normalizedCorsHost = corsHost.trim()
-    this.corsOrigins = normalizedCorsHost.includes(',')
-      ? normalizedCorsHost
-          .split(',')
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0)
-      : normalizedCorsHost
+    this.corsOrigins = parseCorsOrigins(corsHost)
     this.transcoder = transcoder
     this.init()
   }

--- a/backend/src/api/express.ts
+++ b/backend/src/api/express.ts
@@ -13,7 +13,13 @@ export class API {
   constructor(transcoder: Transcoder, corsHost: string, port?: number) {
     this.app = express()
     this.port = port || 3000
-    this.corsOrigins = corsHost.includes(',') ? corsHost.split(',').map((s) => s.trim()) : corsHost
+    const normalizedCorsHost = corsHost.trim()
+    this.corsOrigins = normalizedCorsHost.includes(',')
+      ? normalizedCorsHost
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : normalizedCorsHost
     this.transcoder = transcoder
     this.init()
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-convert-to-hls",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": "https://github.com/bossoq/auto-convert-to-hls.git",
   "author": "Kittipos Wajakajornrit <kwajakajornrit@gmail.com>",
   "license": "MIT",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "dev": "vite dev",
     "build": "svelte-kit sync && vite build",

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -24,7 +24,9 @@
     easing: cubicOut
   })
 
-  const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '')
+  const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
+    transports: ['websocket'],
+  })
 
   socket.on('status', (data) => {
     currentStatus = data

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -25,7 +25,7 @@
   })
 
   const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
-    transports: ['websocket'],
+    transports: ['websocket']
   })
 
   socket.on('status', (data) => {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import { tweened } from 'svelte/motion'
   import { cubicOut } from 'svelte/easing'
+  import type { Socket } from 'socket.io-client'
 
   let currentStatus = {
     busy: false,
@@ -23,30 +24,33 @@
     easing: cubicOut
   })
 
-  onMount(async () => {
-    const { default: io } = await import('socket.io-client')
-    const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
-      transports: ['websocket']
-    })
+  let socket: Socket | undefined
 
-    socket.on('status', (data) => {
-      currentStatus = data
-      progress.set(
-        currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
-      )
-    })
+  onMount(() => {
+    import('socket.io-client').then(({ default: io }) => {
+      socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
+        transports: ['websocket']
+      })
 
-    socket.on('queue', (data) => {
-      queue = data
-    })
+      socket.on('status', (data) => {
+        currentStatus = data
+        progress.set(
+          currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
+        )
+      })
 
-    socket.on('connect_error', (err) => {
-      console.error('Socket connection error:', err.message)
-    })
+      socket.on('queue', (data) => {
+        queue = data
+      })
 
-    return () => {
-      socket.disconnect()
-    }
+      socket.on('connect_error', (err) => {
+        console.error('Socket connection error:', err.message)
+      })
+    })
+  })
+
+  onDestroy(() => {
+    socket?.disconnect()
   })
 </script>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
+  import { onMount } from 'svelte'
   import { tweened } from 'svelte/motion'
   import { cubicOut } from 'svelte/easing'
   import type { Socket } from 'socket.io-client'
@@ -27,30 +27,39 @@
   let socket: Socket | undefined
 
   onMount(() => {
-    import('socket.io-client').then(({ io }) => {
-      socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
-        transports: ['websocket']
+    let cancelled = false
+
+    import('socket.io-client')
+      .then(({ io }) => {
+        if (cancelled) return
+
+        socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
+          transports: ['websocket']
+        })
+
+        socket.on('status', (data) => {
+          currentStatus = data
+          progress.set(
+            currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
+          )
+        })
+
+        socket.on('queue', (data) => {
+          queue = data
+        })
+
+        socket.on('connect_error', (err) => {
+          console.error('Socket connection error:', err.message)
+        })
+      })
+      .catch((err) => {
+        console.error('Failed to load socket.io-client:', err)
       })
 
-      socket.on('status', (data) => {
-        currentStatus = data
-        progress.set(
-          currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
-        )
-      })
-
-      socket.on('queue', (data) => {
-        queue = data
-      })
-
-      socket.on('connect_error', (err) => {
-        console.error('Socket connection error:', err.message)
-      })
-    })
-  })
-
-  onDestroy(() => {
-    socket?.disconnect()
+    return () => {
+      cancelled = true
+      socket?.disconnect()
+    }
   })
 </script>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -27,7 +27,7 @@
   let socket: Socket | undefined
 
   onMount(() => {
-    import('socket.io-client').then(({ default: io }) => {
+    import('socket.io-client').then(({ io }) => {
       socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
         transports: ['websocket']
       })

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte'
   import { tweened } from 'svelte/motion'
   import { cubicOut } from 'svelte/easing'
-  import io from 'socket.io-client'
 
   let currentStatus = {
     busy: false,
@@ -24,29 +23,30 @@
     easing: cubicOut
   })
 
-  const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
-    transports: ['websocket']
-  })
+  onMount(async () => {
+    const { default: io } = await import('socket.io-client')
+    const socket = io(import.meta.env.PUBLIC_SOCKET_URL || '', {
+      transports: ['websocket']
+    })
 
-  socket.on('status', (data) => {
-    currentStatus = data
-    progress.set(
-      currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
-    )
-  })
+    socket.on('status', (data) => {
+      currentStatus = data
+      progress.set(
+        currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
+      )
+    })
 
-  socket.on('queue', (data) => {
-    queue = data
-  })
+    socket.on('queue', (data) => {
+      queue = data
+    })
 
-  socket.on('connect_error', (err) => {
-    console.error('Socket connection error:', err.message)
-  })
+    socket.on('connect_error', (err) => {
+      console.error('Socket connection error:', err.message)
+    })
 
-  onMount(() => {
-    progress.set(
-      currentStatus.progress !== 'NaN' ? parseFloat(currentStatus.progress) : 0
-    )
+    return () => {
+      socket.disconnect()
+    }
   })
 </script>
 


### PR DESCRIPTION
## Summary

- Force WebSocket-only transport on the Socket.io client (`web/src/routes/+page.svelte`) to bypass XHR long-polling, which fails when a reverse proxy doesn't forward HTTP polling requests to the backend port
- Accept comma-separated list of origins in `CORSHOST` (`backend/src/api/express.ts`) so multiple origins can be allowed without code changes
- Update README: correct Node.js requirement to ≥ 24, document multi-origin `CORSHOST`, note WebSocket-only transport

## Test plan

- [ ] Verify Socket.io connects successfully in the deployed environment (no more `xhr poll error` in browser console)
- [ ] Confirm `CORSHOST=https://a.example.com,https://b.example.com` allows both origins
- [ ] `yarn test` passes

https://claude.ai/code/session_019FteRLhcZcUKMfbWXwXfGh

---
_Generated by [Claude Code](https://claude.ai/code/session_019FteRLhcZcUKMfbWXwXfGh)_