### PR TITLE
Use videoAccess join table for participant access and release v2.0.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "engines": {
     "node": ">=24"
   },

--- a/backend/src/ffmpeg/ffmpeg.ts
+++ b/backend/src/ffmpeg/ffmpeg.ts
@@ -258,8 +258,12 @@ ${r.height}.m3u8`
             baseUrl: `${VodBaseUrl}/${queue.name}`,
             type: 'vod',
             allowAll: false,
-            allowList: queue.meta.participants,
             fileType: 'HLS',
+            videoAccess: {
+              create: queue.meta.participants.map((userId) => ({
+                userId: BigInt(userId),
+              })),
+            },
           },
         })
         if (this.options.showLogs) console.log(`Auto Publish Done!`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-convert-to-hls",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "repository": "https://github.com/bossoq/auto-convert-to-hls.git",
   "author": "Kittipos Wajakajornrit <kwajakajornrit@gmail.com>",
   "license": "MIT",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "scripts": {
     "dev": "vite dev",
     "build": "svelte-kit sync && vite build",


### PR DESCRIPTION
## Summary

- Replace `allowList` JSON field on `videoTable` with normalized `videoAccess` rows (one per participant user ID)
- `autoPublish` now inserts `videoAccess` records via Prisma nested create instead of storing a JSON array
- Bump all packages to 2.0.4

## Test plan

- [x] All 42 existing tests pass
- [x] Prisma client regenerated against updated schema
- [ ] Verify `videoAccess` rows are created correctly after a transcode with `autoPublish=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)